### PR TITLE
updates heading styles to add class option to inherit heading styles

### DIFF
--- a/stylesheets/partials/core/_headings.scss
+++ b/stylesheets/partials/core/_headings.scss
@@ -4,19 +4,26 @@ h1, h2, h3, h4 {
 	margin-bottom: .25em;
 }
 
-h1 {
+h1,
+.h1 {
 	font-size: 2.5em;
 	font-weight: 900;
 	color: $dark-gray;
 }
 
-h2 {
+h2,
+.h2 {
 	font-size: 1.8em;
 	font-weight: 900;
 	color: $tan;
+
+	&.h3 {
+		margin-top: 1em; //23111-header-class - overwrite bootstrap style
+	}
 }
 
-h3 {
+h3,
+.h3 {
 	font-size: 1.2em;
 	font-weight: 900;
 	color: $tan;


### PR DESCRIPTION
Leveraged the existing header classes (.h1, .h2, .h3) to add the properties of those headers to other text since it is a pretty common technique and is used in other places already in the code base.

I did have to write one additional selector to overwrite a bootstrap style that was calculating the line-height in a way that was not replicating the line-spacing we have on production currently.